### PR TITLE
overhaul to new fixel directory format

### DIFF
--- a/my_fba.sh
+++ b/my_fba.sh
@@ -13,7 +13,7 @@ voxelsize=1.0
 nTracksOrig=20000000
 nTracksSift=2000000
 fixel_metric="fd"
-nthreads=7
+nthreads=6
 ### end defaults
 
 

--- a/my_fba.sh
+++ b/my_fba.sh
@@ -276,6 +276,12 @@ do
     continue
   fi
 
+  if [ ! -f ${FBA_DIR}/${subj}/dwis.mif ]
+  then
+    echo "  [INFO] $subj is not a valid subject."
+    continue
+  fi
+
   echo "  [INFO] Submitting job $stepToRun for subject $subj"
 
   case $stepToRun in

--- a/my_fba.sh
+++ b/my_fba.sh
@@ -13,6 +13,7 @@ voxelsize=1.0
 nTracksOrig=20000000
 nTracksSift=2000000
 fixel_metric="fd"
+nthreads=7
 ### end defaults
 
 
@@ -46,6 +47,7 @@ Options:
                                 Default is $nTracksOrig
 -nTracksSift <int>            : Number of tracks to keep after SIFT
                                 Default is $nTracksSift
+-nthreads <int>               : Number of threads per job.
 
 Note that -analysis_prefix and -results_prefix are mandatory if the Step stats is to be executed.
 
@@ -183,6 +185,11 @@ do
    echo "  [INFO] User specified fixel metric to evaluate in stats, setting it to $fixel_metric"
    shift;shift
   ;;
+  -nthreads)
+   nthreads=$2
+   echo "  [INFO] User specified nthreads: $nthreads"
+   shift;shift
+  ;;
   esac
 done
 
@@ -275,51 +282,51 @@ do
     echo "  This is just a test for subject $subj"
   ;;
   qtest)
-    fsl_sub -R 3 -N s${subj}_test -l ${FBA_DIR}/logs \
+    fsl_sub -s smp,$nthreads -N s${subj}_test -l ${FBA_DIR}/logs \
     my_fba_test.sh $subj
   ;;
   mask)
-    fsl_sub -R 3 -N s${subj}_mask -l ${FBA_DIR}/logs \
+    fsl_sub -s smp,$nthreads -N s${subj}_mask -l ${FBA_DIR}/logs \
         my_fba_mask.sh $subj
   ;;
   std_signal)
-    fsl_sub -R 3 -N s${subj}_std -l ${FBA_DIR}/logs \
+    fsl_sub -s smp,$nthreads -N s${subj}_std -l ${FBA_DIR}/logs \
         my_fba_stdSignal.sh $subj fa
   ;;
   response)
-    fsl_sub -R 3 -N s${subj}_resp -l ${FBA_DIR}/logs \
+    fsl_sub -s smp,$nthreads -N s${subj}_resp -l ${FBA_DIR}/logs \
         my_fba_response.sh $subj
   ;;
   upsample)
-    fsl_sub -R 3 -N s${subj}_up -l ${FBA_DIR}/logs -R 6 \
+    fsl_sub -s smp,$nthreads -N s${subj}_up -l ${FBA_DIR}/logs -R 6 \
         my_fba_upsample.sh $subj $voxelsize
   ;;
   fod)
-    fsl_sub -R 3 -N s${subj}_fod -l ${FBA_DIR}/logs -R 6 \
+    fsl_sub -s smp,$nthreads -N s${subj}_fod -l ${FBA_DIR}/logs -R 6 \
         my_fba_fod.sh $subj
   ;;
   fod2template)
-     fsl_sub -R 3 -N s${subj}_rfod -l ${FBA_DIR}/logs -R 6 \
+     fsl_sub -s smp,$nthreads -N s${subj}_rfod -l ${FBA_DIR}/logs -R 6 \
         my_fba_fod2template.sh $subj
   ;;
   afd)
-     fsl_sub -R 3 -N s${subj}_afd -l ${FBA_DIR}/logs -R 6 \
+     fsl_sub -s smp,$nthreads -N s${subj}_afd -l ${FBA_DIR}/logs -R 6 \
         my_fba_afd.sh $subj
   ;;
   fixel_reorient)
-     fsl_sub -R 3 -N s${subj}_fr -l ${FBA_DIR}/logs -R 6 \
+     fsl_sub -s smp,$nthreads -N s${subj}_fr -l ${FBA_DIR}/logs -R 6 \
         my_fba_fixelReorient.sh $subj
   ;;
   fixel_correspondence)
-     fsl_sub -R 3 -N s${subj}_fc -l ${FBA_DIR}/logs -R 6 \
+     fsl_sub -s smp,$nthreads -N s${subj}_fc -l ${FBA_DIR}/logs -R 6 \
         my_fba_fixelcorrespondence.sh $subj
   ;;
   fixel_metrics)
-     fsl_sub -R 3 -N s${subj}_fm -l ${FBA_DIR}/logs -R 6 \
+     fsl_sub -s smp,$nthreads -N s${subj}_fm -l ${FBA_DIR}/logs -R 6 \
         my_fba_computeMetrics.sh $subj
   ;;
   simplemetrics)
-     fsl_sub -R 3 -N s${subj}_t -l ${FBA_DIR}/logs -R 6 \
+     fsl_sub -s smp,$nthreads -N s${subj}_t -l ${FBA_DIR}/logs -R 6 \
         my_fba_simplemetrics.sh $subj
   ;;
   *)

--- a/my_fba.sh
+++ b/my_fba.sh
@@ -212,17 +212,17 @@ done
     exit 0
   ;;
   maskIntersection)
-    fsl_sub -N maskIntx -l ${FBA_DIR}/logs \
+    fsl_sub -s smp,$nthreads  -N maskIntx -l ${FBA_DIR}/logs \
     my_fba_maskIntersection.sh
     exit 0
   ;;
   fixel_mask)
-    fsl_sub -N fixelmask -l ${FBA_DIR}/logs \
+    fsl_sub -s smp,$nthreads  -N fixelmask -l ${FBA_DIR}/logs \
     my_fba_createFixelMask.sh $fixel_mask_threshold
     exit 0
   ;;
   tracto)
-    fsl_sub -N tracto -l ${FBA_DIR}/logs \
+    fsl_sub -s smp,$nthreads  -N tracto -l ${FBA_DIR}/logs \
     my_fba_fullTemplateTracto.sh $nTracksOrig $nTracksSift
     exit 0
   ;;

--- a/my_fba.sh
+++ b/my_fba.sh
@@ -3,7 +3,7 @@
 
 ### Defaults
 list_of_subjects=""
-fixel_mask_threshold=0.25
+fixel_mask_threshold=0.06
 fwhm=10
 nperms=5000
 prefix=""

--- a/my_fba.sh
+++ b/my_fba.sh
@@ -66,6 +66,7 @@ response              : 4. Compute the response function.
 av_response           : 5. Average all subjects response functions to a single one.
                            This response function will be used to estimate FODs on each subject.
 fod                   : 6. Compute the FOD
+mtnormalise           : 6a. Multi-tissue intensity normalisation of FODs.
 build_fod_template    : 7. Build the FOD template. Very time consuming.
 fod2template          : 8. Register the subject FOD to the template FOD.
 maskIntersection      : 9. Calculate the intersection of masks of all subjects.
@@ -304,6 +305,10 @@ do
   fod)
     fsl_sub -s smp,$nthreads -N s${subj}_fod -l ${FBA_DIR}/logs -R 6 \
         my_fba_fod.sh $subj
+  ;;
+  mtnormalise)
+    fsl_sub -s smp,$nthreads -N s${subj}_fod -l ${FBA_DIR}/logs -R 6 \
+        my_fba_mtnormalise.sh $subj
   ;;
   fod2template)
      fsl_sub -s smp,$nthreads -N s${subj}_rfod -l ${FBA_DIR}/logs -R 6 \

--- a/my_fba.sh
+++ b/my_fba.sh
@@ -79,7 +79,12 @@ fixel_metrics         : 14. Compute fibre cross-section (FC) and fibre density a
 tracto                : 15. Run tractography on the template FOD.
                             Will create $nTracksOrig tracks
                             then run SIFT to get it down to $nTracksSift.
-stats                 : 16. Compute statistics
+fixelconnectivity     : 16. Compute the fixel-fixel connectivity  matrix.
+                            It is highly recommended to increase -nthreads
+                            (check your cluster with qhost and find how high you can go)
+fixelfilter           : 17. Smooth the fixels. 
+                            Change the fwhm using -fwhm. Default is $fwhm.
+stats                 : 18. Compute statistics
                             Requires some additional information, supplied by these switches:
                             -analysis_prefix <string> (no default)
                             -results_prefix   <string> (no default)
@@ -224,6 +229,18 @@ done
   tracto)
     fsl_sub -s smp,$nthreads  -N tracto -l ${FBA_DIR}/logs \
     my_fba_fullTemplateTracto.sh $nTracksOrig $nTracksSift
+    exit 0
+  ;;
+  fixelfilter)
+    echo "[INFO] This step needs a lot of RAM. fsl_sub will try to find a PC with at least 24G."
+    fsl_sub -s smp,$nthreads  -N fixelfilt -l ${FBA_DIR}/logs -R 24000 \
+    my_fba_fixelfilter.sh $fwhm
+    exit 0
+  ;;
+  fixelconnectivity)
+    echo "[INFO] This step needs a lot of RAM. fsl_sub will try to find a PC with at least 24G."
+    fsl_sub -s smp,$nthreads  -N fixelconn -l ${FBA_DIR}/logs -R 24000 \
+    my_fba_fixelconnectivity.sh
     exit 0
   ;;
   stats)

--- a/my_fba_afd.sh
+++ b/my_fba_afd.sh
@@ -19,29 +19,31 @@ subj=$1
 # 9. Segment FOD images to estimate fixels and their fibre density (FD)
 # Here we segment each FOD lobe to identify the number and orientation of fixels in each voxel. The output also contains the apparent fibre density (AFD) value per fixel estimated as the FOD lobe integral. Note that in the following steps we will use a more generic shortened acronym - Fibre Density (FD) instead of AFD.
 
-sub_fixeldir=${FBA_DIR}/${subj}/fixels
-fd_noReoriented=fd_templateSpace_noReorient.mif
+# inputs
 fod_std=${FBA_DIR}/${subj}/fod_templateSpace_noReorient.mif
 analysis_voxel_mask=${FBA_DIR}/template_analysis_voxel_mask.mif
 
-if [ -f $fd_noReoriented ]
+# outputs
+sub_fixeldir=${FBA_DIR}/${subj}/fixels_in_template_space_NOT_REORIENTED
+fd_noReoriented=fd.mif
+
+
+fcheck=${sub_fixeldir}/${fd_noReoriented}
+if [ -f $fcheck ]
 then
-  echo "  [INFO] File exists: $fd_noReoriented"
+  echo "  [INFO] File exists: $fcheck"
   exit 0
 fi
 
 
-if [ ! -f $fod_std ]
-then
-  echo "  [ERROR] Cannot find file: $fod_std"
-  exit 2
-fi
-
-if [ ! -f $analysis_voxel_mask ]
-then
-  echo "  [ERROR] Cannot find file: $analysis_voxel_mask"
-  exit 2
-fi
+for f in $fod_std $analysis_voxel_mask
+do
+  if [ ! -f $f ]
+  then
+    echo "  [ERROR] Cannot find file: $f"
+    exit 2
+  fi
+done
 
 
 

--- a/my_fba_afd.sh
+++ b/my_fba_afd.sh
@@ -19,7 +19,7 @@ subj=$1
 # 9. Segment FOD images to estimate fixels and their fibre density (FD)
 # Here we segment each FOD lobe to identify the number and orientation of fixels in each voxel. The output also contains the apparent fibre density (AFD) value per fixel estimated as the FOD lobe integral. Note that in the following steps we will use a more generic shortened acronym - Fibre Density (FD) instead of AFD.
 
-fd_noReoriented=${FBA_DIR}/${subj}/fd_templateSpace_noReorient.msf
+fd_noReoriented=${FBA_DIR}/${subj}/fd_templateSpace_noReorient
 fod_std=${FBA_DIR}/${subj}/fod_templateSpace_noReorient.mif
 analysis_voxel_mask=${FBA_DIR}/template_analysis_voxel_mask.mif
 

--- a/my_fba_afd.sh
+++ b/my_fba_afd.sh
@@ -21,7 +21,7 @@ subj=$1
 
 # inputs
 fod_std=${FBA_DIR}/${subj}/fod_templateSpace_noReorient.mif
-analysis_voxel_mask=${FBA_DIR}/template_analysis_voxel_mask.mif
+analysis_voxel_mask=${FBA_DIR}/template/analysis_voxel_mask.mif
 
 # outputs
 sub_fixeldir=${FBA_DIR}/${subj}/fixels_in_template_space_NOT_REORIENTED

--- a/my_fba_afd.sh
+++ b/my_fba_afd.sh
@@ -19,7 +19,8 @@ subj=$1
 # 9. Segment FOD images to estimate fixels and their fibre density (FD)
 # Here we segment each FOD lobe to identify the number and orientation of fixels in each voxel. The output also contains the apparent fibre density (AFD) value per fixel estimated as the FOD lobe integral. Note that in the following steps we will use a more generic shortened acronym - Fibre Density (FD) instead of AFD.
 
-fd_noReoriented=${FBA_DIR}/${subj}/fd_templateSpace_noReorient
+sub_fixeldir=${FBA_DIR}/${subj}/fixels
+fd_noReoriented=fd_templateSpace_noReorient.mif
 fod_std=${FBA_DIR}/${subj}/fod_templateSpace_noReorient.mif
 analysis_voxel_mask=${FBA_DIR}/template_analysis_voxel_mask.mif
 
@@ -47,4 +48,5 @@ fi
 my_do_cmd fod2fixel \
   $fod_std \
   -mask $analysis_voxel_mask \
-  -afd $fd_noReoriented
+  -afd $fd_noReoriented \
+  $sub_fixeldir

--- a/my_fba_av_response.sh
+++ b/my_fba_av_response.sh
@@ -58,6 +58,6 @@ av_response=${FBA_DIR}/average_${tissue}_response.txt
     exit 2
   fi
 
-  my_do_cmd average_response ${FBA_DIR}/*/${tissue}_response.txt $av_response
+  my_do_cmd responsemean ${FBA_DIR}/*/${tissue}_response.txt $av_response
 
 done

--- a/my_fba_build_template.sh
+++ b/my_fba_build_template.sh
@@ -49,10 +49,10 @@ fi
 # fi
 
 
-mkdir -p ${FBA_DIR}/logs/template
+mkdir -p ${FBA_DIR}/template
 
-ln_fod_dir=${FBA_DIR}/logs/template/fods
-ln_mask_dir=${FBA_DIR}/logs/template/masks
+ln_fod_dir=${FBA_DIR}/template/fods
+ln_mask_dir=${FBA_DIR}/template/masks
 for d in $ln_fod_dir $ln_mask_dir
   do
   if [ ! -d $d ]
@@ -66,7 +66,7 @@ echo "  [INFO] Making sure the template directories are empty"
 rm ${ln_fod_dir}/*
 rm ${ln_mask_dir}/*
 
-subjects_file=${FBA_DIR}/logs/template/subjects_to_build_template_from.txt
+subjects_file=${FBA_DIR}/template/subjects_to_build_template_from.txt
 
 
 
@@ -76,7 +76,7 @@ then
   cp $nsubjs $subjects_file
 fi
 
-available_subjects_file=${FBA_DIR}/logs/template/available_subjects_to_build_template_from.txt
+available_subjects_file=${FBA_DIR}/template/available_subjects_to_build_template_from.txt
 ls ${FBA_DIR}/*/wm_fod.mif > $available_subjects_file
 n_available_subjects=`wc -l $available_subjects_file | awk '{print $1}'`
 
@@ -133,8 +133,8 @@ echo "  [INFO] It is best to run this step on an execution host.
 
 my_do_cmd -fake population_template \
   -mask_dir $ln_mask_dir \
-  -warp_dir ${FBA_DIR}/logs/template/warps \
-  -linear_transformations_dir ${FBA_DIR}/logs/template/xfms \
-  -template_mask ${FBA_DIR}/logs/template/template_mask.mif \
+  -warp_dir ${FBA_DIR}/template/warps \
+  -linear_transformations_dir ${FBA_DIR}/template/xfms \
+  -template_mask ${FBA_DIR}/template/mask.mif \
   $ln_fod_dir  \
-  ${FBA_DIR}/template_fod.mif
+  ${FBA_DIR}/template/fod.mif

--- a/my_fba_computeMetrics.sh
+++ b/my_fba_computeMetrics.sh
@@ -7,29 +7,62 @@ subj=$1
 
 
 # 12. Compute fibre cross-section (FC) metric
-# Apparent fibre density, and other related measures that are influenced by the quantity of restricted water, only permit the investigation of group differences in the number of axons that manifest as a change to within-voxel density. However, depending on the disease type and stage, changes to the number of axons may also manifest as macroscopic differences in brain morphology. This step computes a fixel-based metric related to morphological differences in fibre cross-section, where information is derived entirely from the warps generated during registration (paper under review):
+# Apparent fibre density, and other related measures that are influenced by the quantity of restricted water,
+# only permit the investigation of group differences in the number of axons that manifest as a change to within-voxel density. 
+# However, depending on the disease type and stage, changes to the number of axons may also manifest as macroscopic differences
+# in brain morphology. This step computes a fixel-based metric related to morphological differences in fibre cross-section,
+# where information is derived entirely from the warps generated during registration (paper under review):
 
 
+
+echo "[INFO] Computing fc"
 warp_subj2template=${FBA_DIR}/${subj}/fod_subj2template_warp.mif
-analysis_fixel_mask=${FBA_DIR}/template_analysis_fixel_mask.msf
-subject_fc=${FBA_DIR}/${subj}/fc_templateSpace_corresp2template.msf
-subject_fc_log=${FBA_DIR}/${subj}/fc_log_templateSpace_corresp2template.msf
-subject_jdet=${FBA_DIR}/${subj}/jacobian_determinant.mif
-subject_fd=${FBA_DIR}/${subj}/fd_templateSpace_corresp2template.msf
-subject_fdc=${FBA_DIR}/${subj}/fdc_templateSpace_corresp2template.msf
-
-my_do_cmd warp2metric $warp_subj2template -fc $analysis_fixel_mask $subject_fc
-my_do_cmd warp2metric $warp_subj2template -jdet $subject_jdet
-
-
-
-# The FC files will be used in the next step. However, for group statistical analysis of FC we recommend taking the log (FC) to ensure data are centred about zero and normally distributed:
-
-my_do_cmd fixellog $subject_fc $subject_fc_log
+fixel_mask=${FBA_DIR}/template/fixel_mask
+template_fd=${FBA_DIR}/template/fd
+template_fc=${FBA_DIR}/template/fc
+template_log_fc=${FBA_DIR}/template/log_fc
+template_fdc=${FBA_DIR}/template/fdc
+subj_fd=${subj}.mif
+subj_fc=${subj}.mif
+subj_log_fc=${subj}.mif
+subj_fdc=${subj}.mif
 
 
+fcheck=${template_fc}/${subj_fc}
+if [ ! -f $fcheck ]
+then
+my_do_cmd warp2metric \
+  $warp_subj2template \
+  -fc \
+    $fixel_mask \
+    $template_fc \
+    $subj_fc
+else
+  echo "[INFO] File exists, not overwriting: $fcheck"
+fi
 
-# 13. Compute a combined measure of fibre density and cross-section (FDC)
-# To account for changes to both within-voxel fibre density and macroscopic atrophy, fibre density and fibre cross-section must be combined (a measure we call fibre density & cross-section, FDC). This enables a more complete picture of group differences in white matter. Note that as discussed in our future work (under review), group differences in FD or FC alone must be interpreted with care in crossing-fibre regions. However group differences in FDC are more directly interpretable. To generate the combined measure we ‘modulate’ the FD by FC:
 
-my_do_cmd fixelcalc $subject_fd mult $subject_fc $subject_fdc
+echo "[INFO] Computing log_fc"
+if [ ! -d $template_log_fc ]; then mkdir -v $template_log_fc; fi
+if [ ! -f ${template_log_fc}/directions.mif ]
+then
+	my_do_cmd cp ${template_fc}/index.mif ${template_fc}/directions.mif $template_log_fc/
+fi
+mrcalc \
+  ${template_fc}/$subj_fc \
+  -log \
+  ${template_log_fc}/${subj_log_fc}
+
+
+
+echo "[INFO] Compute combined fd and fc (fdc)"
+if [ ! -d $template_fdc ]; then mkdir -v $template_fdc;fi
+if [ ! -f ${template_fdc}/directions.mif ]
+then
+	my_do_cmd cp ${template_fc}/index.mif ${template_fc}/directions.mif $template_fdc/
+fi
+mrcalc \
+  ${template_fd}/${subj_fd} \
+  ${template_fc}/${subj_fc} \
+  -mult \
+ ${template_fdc}/${subj_fdc}

--- a/my_fba_createFixelMask.sh
+++ b/my_fba_createFixelMask.sh
@@ -48,41 +48,18 @@ then
   echo "  [ERROR] Cannot create a fixel image from the template fod."
   exit 2
 fi
-template_peaks=${FBA_DIR}/template_peaks.msf
+template_peaks=${FBA_DIR}/template_peaks
 my_do_cmd fod2fixel\
-  $template_fod \
   -mask $template_mask \
-  -peak $template_peaks
-
-
-
-
-# Next view the peaks file using the vector plot tool in mrview and identify an appropriate threshold that removes peaks from grey matter, yet does not introduce any ‘holes’ in your white matter (approximately 0.33) (lconcha likes 0.25).
-analysis_fixel_mask_tmp=${tmpDir}/template_analysis_fixel_mask.msf
-my_do_cmd fixelthreshold -crop $template_peaks $peak_threshold $analysis_fixel_mask_tmp
+  $template_fod \
+  $template_peaks
 
 
 
 # Generate an analysis voxel mask from the fixel mask. The median filter in this step should remove spurious voxels outside the brain, and fill in the holes in deep white matter where you have small peaks due to 3-fibre crossings:
 analysis_voxel_mask=${FBA_DIR}/template_analysis_voxel_mask.mif
-fixel2voxel $analysis_fixel_mask_tmp count - | mrthreshold - - -abs 0.5 | mrfilter - median $analysis_voxel_mask
-
-# Recompute the fixel mask using the analysis voxel mask. Using the mask allows us to use a lower AFD threshold than possible in the steps above, to ensure we have included fixels with low AFD inside white matter:
-my_do_cmd fod2fixel \
-  -mask $analysis_voxel_mask \
-  $template_fod \
-  -peak ${tmpDir}/template_temp_step.msf
-
-# we finalize the fixel mask
-my_do_cmd fixelthreshold \
-  ${tmpDir}/template_temp_step.msf \
-  -crop 0.2 \
-  $analysis_fixel_mask
-  
- 
-# We recommend having no more than 500,000 fixels in the analysis_fixel_mask (you can check this with fixelstats), otherwise downstream statistical analysis (using fixelcfestats) will run out of RAM). A mask with 500,000 fixels will require a PC with 128GB of RAM for the statistical analysis step.
-nfixels=`fixelstats $analysis_fixel_mask -output count`
-echo "  [INFO] Number of fixels in fixel mask: $nfixels"
-
+my_do_cmd fixel2voxel ${template_peaks}/directions.mif count ${tmpDir}/fixelcounts.mif 
+my_do_cmd mrthreshold ${tmpDir}/fixelcounts.mif ${tmpDir}/fixelcounts_abs.mif -abs 0.5
+my_do_cmd mrfilter ${tmpDir}/fixelcounts_abs.mif median $analysis_voxel_mask
 
 rm -fRv $tmpDir

--- a/my_fba_createFixelMask.sh
+++ b/my_fba_createFixelMask.sh
@@ -17,11 +17,11 @@ fi
 
 template_fod=${FBA_DIR}/template_fod.mif
 template_mask=${FBA_DIR}/template_mask_intersection.mif
-analysis_fixel_mask=${FBA_DIR}/template_analysis_fixel_mask.msf
+template_fixel_mask=${FBA_DIR}/template_fixel_mask
 
-if [ -f $analysis_fixel_mask ]
+if [ -d $template_fixel_mask ]
 then
-  echo "  [INFO] Analysis fixel mask exists: $analysis_fixel_mask"
+  echo "  [INFO] Analysis fixel mask exists: $template_fixel_mask"
   echo "         Not overwriting. Exit now."
   exit 0
 fi
@@ -61,5 +61,13 @@ analysis_voxel_mask=${FBA_DIR}/template_analysis_voxel_mask.mif
 my_do_cmd fixel2voxel ${template_peaks}/directions.mif count ${tmpDir}/fixelcounts.mif 
 my_do_cmd mrthreshold ${tmpDir}/fixelcounts.mif ${tmpDir}/fixelcounts_abs.mif -abs 0.5
 my_do_cmd mrfilter ${tmpDir}/fixelcounts_abs.mif median $analysis_voxel_mask
+
+# Generate a fixel mask
+my_do_cmd fod2fixel \
+  -mask $analysis_voxel_mask  \
+  -fmls_peak_value 0.06 \
+  $template_fod \
+  $template_fixel_mask
+
 
 rm -fRv $tmpDir

--- a/my_fba_fixelReorient.sh
+++ b/my_fba_fixelReorient.sh
@@ -21,13 +21,20 @@ subj=$1
 # Here we reorient the direction of all fixels based on the Jacobian matrix (local affine transformation) at each voxel in the warp:
 
 
-fd_std_noReorient=${FBA_DIR}/${subj}/fd_templateSpace_noReorient.msf
+fd_std_noReorient=${FBA_DIR}/${subj}/fixels
 warp_subj2template=${FBA_DIR}/${subj}/fod_subj2template_warp.mif
-fd_std_reorient=${FBA_DIR}/${subj}/fd_templateSpace_reorient.msf
+fd_std_reorient=${FBA_DIR}/${subj}/fixels_reoriented
 
 
 isOK=1
-for f in $fd_std_noReorient $warp_subj2template
+
+if [ ! -d $fd_std_noReorient ]
+then
+    echo "  [ERROR] Cannot find fixel directory: $fd_std_noReorient"
+    isOK=0
+fi
+
+for f in $warp_subj2template
 do
   if [ ! -f $f ]
   then

--- a/my_fba_fixelReorient.sh
+++ b/my_fba_fixelReorient.sh
@@ -21,16 +21,16 @@ subj=$1
 # Here we reorient the direction of all fixels based on the Jacobian matrix (local affine transformation) at each voxel in the warp:
 
 
-fd_std_noReorient=${FBA_DIR}/${subj}/fixels
+fixels_std_noReorient=${FBA_DIR}/${subj}/fixels_in_template_space_NOT_REORIENTED
 warp_subj2template=${FBA_DIR}/${subj}/fod_subj2template_warp.mif
-fd_std_reorient=${FBA_DIR}/${subj}/fixels_reoriented
+fixels_std_reorient=${FBA_DIR}/${subj}/fixels_in_template_space_reoriented
 
 
 isOK=1
 
-if [ ! -d $fd_std_noReorient ]
+if [ ! -d $fixels_std_noReorient ]
 then
-    echo "  [ERROR] Cannot find fixel directory: $fd_std_noReorient"
+    echo "  [ERROR] Cannot find fixel directory: $fixels_std_noReorient"
     isOK=0
 fi
 
@@ -51,6 +51,6 @@ fi
 
 echo "  [INFO] Performing fixel reorientaion"
 my_do_cmd fixelreorient \
-  $fd_std_noReorient \
+  $fixels_std_noReorient \
   $warp_subj2template \
-  $fd_std_reorient
+  $fixels_std_reorient

--- a/my_fba_fixelconnectivity.sh
+++ b/my_fba_fixelconnectivity.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+fixel_mask=${FBA_DIR}/template/fixel_mask
+tracto_sifted=${FBA_DIR}/template/fullTracto_sifted.tck
+matrix=${FBA_DIR}/template/matrix
+
+if [ -d $matrix ]
+then
+  echo "[INFO] Output exists, not overwriting: $matrix"
+  exit 0
+fi
+
+
+
+fixelconnectivity \
+  $fixel_mask \
+  $tracto_sifted \
+  $matrix

--- a/my_fba_fixelcorrespondence.sh
+++ b/my_fba_fixelcorrespondence.sh
@@ -23,7 +23,8 @@ subj=$1
 
 
 
-fd_std_reorient=${FBA_DIR}/${subj}/fixels_reoriented/fd_templateSpace_noReorient.mif
+fixels_std_reorient=${FBA_DIR}/${subj}/fixels_in_template_space_reoriented
+fd=${fixels_std_reorient}/fd.mif
 template_fixels=${FBA_DIR}/template_peaks
 template_fixel_mask=${FBA_DIR}/template_fixel_mask
 fd_std_corr2template=${FBA_DIR}/${subj}/fixels_corresp2template
@@ -57,10 +58,10 @@ fi
 
 
 my_do_cmd fixelcorrespondence \
-  $fd_std_reorient \
+  $fd \
   $template_fixels \
   $fd_std_corr2template \
   $fout
 
 
-ln -s -v  $fd_std_corr2template/$fout  ${template_fixel_mask}/${subj}_fixelcorresp.mif
+ln -s -v -f $fd_std_corr2template/$fout  ${template_fixel_mask}/${subj}_fixelcorresp.mif

--- a/my_fba_fixelcorrespondence.sh
+++ b/my_fba_fixelcorrespondence.sh
@@ -23,12 +23,19 @@ subj=$1
 
 
 
-fixels_std_reorient=${FBA_DIR}/${subj}/fixels_in_template_space_reoriented
-fd=${fixels_std_reorient}/fd.mif
-template_fixels=${FBA_DIR}/template_peaks
-template_fixel_mask=${FBA_DIR}/template_fixel_mask
-fd_std_corr2template=${FBA_DIR}/${subj}/fixels_corresp2template
-fout=corresp.mif
+fd_fixels_std_reorient=${FBA_DIR}/${subj}/fixels_in_template_space_reoriented/fd.mif
+template_fd=${FBA_DIR}/template/fd
+template_fixel_mask=${FBA_DIR}/template/fixel_mask
+subj_fd_reoriented=${subj}.mif
+
+
+fcheck=${template_fd}/${subj_fd_reoriented}
+if [ -f $fcheck ]
+then
+  echo "[INFO] File exists, not overwriting: $fcheck"
+  exit 0
+fi
+
 
 
 isOK=1
@@ -58,10 +65,8 @@ fi
 
 
 my_do_cmd fixelcorrespondence \
-  $fd \
-  $template_fixels \
-  $fd_std_corr2template \
-  $fout
+  $fd_fixels_std_reorient \
+  $template_fixel_mask \
+  $template_fd \
+  $subj_fd_reoriented
 
-
-ln -s -v -f $fd_std_corr2template/$fout  ${template_fixel_mask}/${subj}_fd.mif

--- a/my_fba_fixelcorrespondence.sh
+++ b/my_fba_fixelcorrespondence.sh
@@ -64,4 +64,4 @@ my_do_cmd fixelcorrespondence \
   $fout
 
 
-ln -s -v -f $fd_std_corr2template/$fout  ${template_fixel_mask}/${subj}_fixelcorresp.mif
+ln -s -v -f $fd_std_corr2template/$fout  ${template_fixel_mask}/${subj}_fd.mif

--- a/my_fba_fixelcorrespondence.sh
+++ b/my_fba_fixelcorrespondence.sh
@@ -23,13 +23,15 @@ subj=$1
 
 
 
-fd_std_reorient=${FBA_DIR}/${subj}/fd_templateSpace_reorient.msf
-analysis_fixel_mask=${FBA_DIR}/template_analysis_fixel_mask.msf
-fd_std_corr2template=${FBA_DIR}/${subj}/fd_templateSpace_corresp2template.msf
+fd_std_reorient=${FBA_DIR}/${subj}/fixels_reoriented/fd_templateSpace_noReorient.mif
+template_fixels=${FBA_DIR}/template_peaks
+template_fixel_mask=${FBA_DIR}/template_fixel_mask
+fd_std_corr2template=${FBA_DIR}/${subj}/fixels_corresp2template
+fout=corresp.mif
 
 
 isOK=1
-for f in $fd_std_reorient $analysis_fixel_mask
+for f in $fd_std_reorient
 do
   if [ ! -f $f ]
   then
@@ -37,6 +39,16 @@ do
     isOK=0
   fi
 done
+
+if [ ! -d $template_fixels ]
+then
+  echo "[ERROR] Cannot find directory: $template_fixels"
+  isOK=0
+fi
+
+
+
+
 if [ $isOK -eq 0 ]
 then
   echo "  [ERROR] Cannot perform fixel correspondence for subject $subj. Quitting."
@@ -44,6 +56,11 @@ then
 fi
 
 
-my_do_cmd fixelcorrespondence $fd_std_reorient \
-  $analysis_fixel_mask \
-  $fd_std_corr2template
+my_do_cmd fixelcorrespondence \
+  $fd_std_reorient \
+  $template_fixels \
+  $fd_std_corr2template \
+  $fout
+
+
+ln -s -v  $fd_std_corr2template/$fout  ${template_fixel_mask}/${subj}_fixelcorresp.mif

--- a/my_fba_fixelfilter.sh
+++ b/my_fba_fixelfilter.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+source `which my_do_cmd`
+echo working on `hostname`
+
+
+fwhm=$1
+
+
+if [ "$#" -lt 1 ]
+then
+  echo "  [ERROR]. Insufficient arguments."
+  echo "  Usage: `basename $0` <fhwm>"
+  echo ""
+  echo "  This script is part of the set of scripts required for fixel-based analyses."
+  echo "  See my_fba.sh for help."
+  exit 2
+fi
+
+
+matrix=${FBA_DIR}/template/matrix
+
+
+isOK=1
+if [ ! -d $matrix ]
+then
+  echo "[ERROR] Cannot find matrix: $matrix"
+  isOK=0
+fi
+
+for metric in fd fdc log_fc
+do
+  d=${FBA_DIR}/template/${metric}
+  if [ ! -d $d ]
+  then
+    echo "[ERROR] Cannot find directory: $d"
+    isOK=0
+  fi
+done
+
+if [ $isOK -eq 0 ]
+then
+  exit 2
+fi
+
+
+
+for metric in fd fdc log_fc
+do
+my_do_cmd fixelfilter \
+  -fwhm $fwhm \
+  ${FBA_DIR}/template/${metric} \
+  smooth \
+  ${FBA_DIR}/template/${metric}_smooth \
+  -matrix $matrix
+done

--- a/my_fba_fod2template.sh
+++ b/my_fba_fod2template.sh
@@ -24,6 +24,15 @@ warp_template2subj=${FBA_DIR}/${subj}/fod_template2subj_warp.mif
 transformed_fod=${FBA_DIR}/${subj}/fod_templateSpace_noReorient.mif
 transformed_mask=${FBA_DIR}/${subj}/mask_templateSpace.mif
 
+
+fcheck=$transformed_fod
+if [ -f $fcheck ]
+then
+  echo "[INFO] File exists, not overwriting: $fcheck"
+  exit 0
+fi
+
+
 echo "  [INFO] Starting FOD registration for subject $subj"
 
 

--- a/my_fba_fod2template.sh
+++ b/my_fba_fod2template.sh
@@ -18,7 +18,7 @@ fi
 
 fod=${FBA_DIR}/${subj}/wm_fod.mif
 mask=${FBA_DIR}/${subj}/mask_upsampled.mif
-fod_template=${FBA_DIR}/template_fod.mif
+fod_template=${FBA_DIR}/template/fod.mif
 warp_subj2template=${FBA_DIR}/${subj}/fod_subj2template_warp.mif
 warp_template2subj=${FBA_DIR}/${subj}/fod_template2subj_warp.mif
 transformed_fod=${FBA_DIR}/${subj}/fod_templateSpace_noReorient.mif

--- a/my_fba_fod2template.sh
+++ b/my_fba_fod2template.sh
@@ -59,7 +59,7 @@ my_do_cmd mrregister $fod \
 echo "  [INFO] Transforming fod to template without fixel reorientation"
 my_do_cmd mrtransform $fod \
   -warp $warp_subj2template \
-  -noreorientation \
+  -reorient_fod no \
   $transformed_fod
 
 

--- a/my_fba_fullTemplateTracto.sh
+++ b/my_fba_fullTemplateTracto.sh
@@ -11,11 +11,11 @@ echo "Running on `hostname`"
 
 nTracksOrig=$1
 nTracksSift=$2
-template_fod=${FBA_DIR}/template_fod.mif
-template_mask=${FBA_DIR}/template_mask_intersection.mif
-analysis_fixel_mask=${FBA_DIR}/template_analysis_fixel_mask.msf
-template_full_tracks=${FBA_DIR}/template_fullTracto.tck
-template_sift_tracks=${FBA_DIR}/template_fullTracto_sifted.tck
+template_fod=${FBA_DIR}/template/fod.mif
+template_mask=${FBA_DIR}/template/template_mask.mif
+analysis_fixel_mask=${FBA_DIR}/template/analysis_fixel_mask.msf
+template_full_tracks=${FBA_DIR}/template/fullTracto.tck
+template_sift_tracks=${FBA_DIR}/template/fullTracto_sifted.tck
 
 angle=22.5
 maxlen=250
@@ -51,7 +51,7 @@ cmd="tckgen \
   $template_fod \
   -seed_image $template_mask \
   -mask $template_mask \
-  -number $nTracksOrig \
+  -select $nTracksOrig \
   $template_full_tracks"
 echo "  --> $cmd"
 time $cmd

--- a/my_fba_maskIntersection.sh
+++ b/my_fba_maskIntersection.sh
@@ -7,8 +7,8 @@ echo "  Running on `hostname`"
 # To ensure subsequent analysis is performed in voxels that contain data from all subjects, 
 # we warp all subject masks into template space and compute the mask intersection. 
 
-mask_intersection=${FBA_DIR}/template_mask_intersection.mif
-mask_prevalence=${FBA_DIR}/template_mask_prevalence.mif
+mask_intersection=${FBA_DIR}/template/template_mask.mif
+mask_prevalence=${FBA_DIR}/template/template_mask_prevalence.mif
 
 listOfMasks=""
 for f in ${FBA_DIR}/*/mask_templateSpace.mif

--- a/my_fba_mtnormalise.sh
+++ b/my_fba_mtnormalise.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+echo "Running on `hostname`"
+source `which my_do_cmd`
+
+if [ "$#" -lt 1 ]
+then
+  echo "  [ERROR]. Insufficient arguments."
+  echo "  Usage: `basename $0` $subj"
+  echo ""
+  echo "  This script is part of the set of scripts required for fixel-based analyses."
+  echo "  See my_fba.sh for help."
+  exit 2
+fi
+
+
+subj=$1
+
+
+wm_fod=${FBA_DIR}/${subj}/wm_fod.mif
+gm_fod=${FBA_DIR}/${subj}/gm_fod.mif
+csf_fod=${FBA_DIR}/${subj}/csf_fod.mif
+mask_upsampled=${FBA_DIR}/${subj}/mask_upsampled.mif
+
+
+
+isOK=1
+for f in $wm_fod $gm_fod $csf_fod $mask_upsampled
+do
+    if [ -f $f ]
+    then
+        echo "  [INFO] File exists: $f"
+    else
+        echo "  [ERROR] Cannot find file: $f"
+        isOK=0
+    fi
+    sz=`du  $f | awk '{print $1}'`
+    if [ $sz -eq 0 ]
+    then
+      echo "  [ERROR] File size is zero for file $f"
+      rm -v $f
+      isOK=0
+    fi
+done
+
+
+if [ $isOK -eq 0 ]
+then
+  echo "  [ERROR] Cannot compute FOD. Quitting."
+  exit 2
+fi
+
+
+wm_fod_norm=${wm_fod%.mif}_normalised.mif
+gm_fod_norm=${gm_fod%.mif}_normalised.mif
+csf_fod_norm=${csf_fod%.mif}_normalised.mif
+f_check_norm=${FBA_DIR}/${subj}/mt_normalisation_factor.mif
+f_check_factors=${FBA_DIR}/${subj}/mt_normalisation_tissue_balance_factors.txt
+
+my_do_cmd mtnormalise \
+    $wm_fod  $wm_fod_norm \
+    $gm_fod  $gm_fod_norm \
+    $csf_fod $csf_fod_norm \
+    -mask $mask_upsampled \
+    -check_norm $f_check_norm \
+    -check_factors $f_check_factors
+  
+

--- a/my_fba_response.sh
+++ b/my_fba_response.sh
@@ -53,7 +53,7 @@ fi
 
 
 my_do_cmd dwi2response dhollander \
-   -scratch ${FBA_DIR}/logs/tmp \
+   -scratch /tmp \
    -mask $mask \
    -voxels ${FBA_DIR}/${subj}/sf_final_mask.mif \
    $dwis \

--- a/my_fba_response.sh
+++ b/my_fba_response.sh
@@ -53,7 +53,7 @@ fi
 
 
 my_do_cmd dwi2response dhollander \
-   -tempdir ${FBA_DIR}/logs/tmp \
+   -scratch ${FBA_DIR}/logs/tmp \
    -mask $mask \
    -voxels ${FBA_DIR}/${subj}/sf_final_mask.mif \
    $dwis \

--- a/my_fba_simplemetrics.sh
+++ b/my_fba_simplemetrics.sh
@@ -8,4 +8,12 @@ mask=${FBA_DIR}/${subj}/mask.mif
 fa=${FBA_DIR}/${subj}/fa.mif
 v1=${FBA_DIR}/${subj}/v1.mif
 
-dwi2tensor -mask $mask $dwis - | tensor2metric -fa $fa -vector $v1 -
+tmpDir=$(mktemp -d)
+
+#dwi2tensor -mask $mask $dwis - | tensor2metric -fa $fa -vector $v1 -
+dwi2tensor -mask $mask $dwis - | tensor2metric -fa ${tmpDir}/fa.mif -vector ${tmpDir}/v1.mif -
+
+cp  ${tmpDir}/fa.mif $fa
+cp  ${tmpDir}/v1.mif $v1
+
+rm -fR $tmpDir

--- a/my_fba_upsample.sh
+++ b/my_fba_upsample.sh
@@ -73,9 +73,11 @@ then
   ln -sv `readlink -f $dwis_std` $dwis_upsampled
   ln -sv `readlink -f $mask` $mask_upsampled
 else
-  my_do_cmd mrresize $dwis_std -voxel $voxelsize $tmpFile1
+  #my_do_cmd mrresize $dwis_std -voxel $voxelsize $tmpFile1
+  my_do_cmd mrgrid -voxel $voxelsize $dwis_std regrid $tmpFile1
   cp -v $tmpFile1 $dwis_upsampled
-  my_do_cmd mrresize -voxel $voxelsize -interp nearest $mask $tmpFile2
+  #my_do_cmd mrresize -voxel $voxelsize -interp nearest $mask $tmpFile2
+  my_do_cmd mrgrid -interp nearest -voxel $voxelsize $mask regrid $tmpFile2
   cp -v $tmpFile2 $mask_upsampled
 fi
 


### PR DESCRIPTION
This merge restores full functionality of this pipeline to mrtrix version 3.0.4, which now uses a fixel directory structure rather than `msf` files and fixes bugs related to deprecated commands.